### PR TITLE
Add autosave feature

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,6 +5,7 @@ import { getReactionGroup } from './reactions/resource';
 import { RemoteDb } from './persistence/remote-db';
 import { v4 as uuidv4 } from 'uuid';
 import { Deserializer } from './persistence/serialization/deserializer';
+import { saveNotesToFile } from './persistence/local-db';
 
 export const saveNoteComment = (
   thread: vscode.CommentThread,
@@ -32,6 +33,7 @@ export const saveNoteComment = (
     thread.contextValue = uuidv4();
     noteMap.set(thread.contextValue, thread);
   }
+  saveNotesToFile(noteMap);
   if (remoteDb) {
     remoteDb.pushNoteComment(thread, firstComment);
   }
@@ -148,6 +150,8 @@ export const syncNoteMapWithRemote = (
       remoteDb && remoteDb.pushNoteComment(localThread, true);
     }
   });
+
+  saveNotesToFile(noteMap);
 };
 
 export const getSetting = (settingName: string, defaultValue?: any) => {

--- a/src/persistence/remote-db/index.ts
+++ b/src/persistence/remote-db/index.ts
@@ -3,6 +3,7 @@ import * as rethinkdb from 'rethinkdb';
 import { Serializer } from '../serialization/serializer';
 import { Deserializer } from '../serialization/deserializer';
 import { readFileSync } from 'fs';
+import { saveNotesToFile } from '../local-db';
 
 export class RemoteDb {
   private host: string;
@@ -134,6 +135,7 @@ export class RemoteDb {
             newThread.contextValue ? newThread.contextValue : '',
             newThread,
           );
+          saveNotesToFile(this.noteMap);
           vscode.window.showInformationMessage('Note received from remote DB.');
         });
       });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,7 +3,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { platform } from 'os';
-import { getSetting } from '../helpers';
 
 export const isWindows = () => {
   return platform() === 'win32';
@@ -26,7 +25,9 @@ export const getWorkspacePath = () => {
 };
 
 export const getLocalDbFilePath = () => {
-  const localDbFilePath = getSetting('localDatabase');
+  const localDbFilePath = vscode.workspace
+    .getConfiguration('security-notes')
+    .get<string>('localDatabase', '.security-notes.json');
   if (path.isAbsolute(localDbFilePath)) {
     return localDbFilePath;
   } else {


### PR DESCRIPTION
Resolves #29 

## Problem

Notes were not saved automatically to the persistence file, resulting in potential loss of information if VSCode exited unexpectedly. 

## Solution

- Persist the local database immediately whenever `saveNoteComment` runs, so file autosaves after every new note, reply, or status change.
- After syncing remote state (`syncNoteMapWithRemote`) or receiving remote updates via RethinkDB subscriptions, write the updated note map to disk to keep local and collaborative data aligned.
- Remove the helper dependency in `utils/index.ts` by reading the `security-notes.localDatabase` setting directly from the VS Code configuration, avoiding circular imports.